### PR TITLE
[TASK] Add compatibility to "subtree split"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "typo3/cms-core": ">=7.6,<9.0",
+    "typo3/cms-core": "^7.6 || ^8.7"
     "sjbr/static-info-tables": "^6.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "typo3/cms": ">=7.6,<9.0",
+    "typo3/cms-core": ">=7.6,<9.0",
     "sjbr/static-info-tables": "^6.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=5.6",
-    "typo3/cms-core": "^7.6 || ^8.7"
+    "typo3/cms-core": "^7.6 || ^8.7",
     "sjbr/static-info-tables": "^6.5"
   },
   "require-dev": {


### PR DESCRIPTION
Since TYPO3 8, you can install TYPO3 in "subtree split" mode, without "typo3/cms". When I add your package to my project, it requires "typo3/cms" and installs it, what breaks my "subtree split" project.
To fix this, the requirement "typo3/cms" is changed to "typo3/cms-core". That's the correct way to require TYPO3 versions for "subtree split" and regular projects.