### PR TITLE
Added extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "extension-key": "static_info_tables_fr",
       "app-dir": ".Build",
       "web-dir": ".Build/public"
     }


### PR DESCRIPTION
Since version 3.1.0 of `typo3/cms-composer-installers` the `extension-key` is required in `composer.json`:
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html

Fixes #10