### PR TITLE
Move from travis-ci to GitHub actions

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -1,0 +1,47 @@
+name: Deploy to TER
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  TER:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: "Determine tag"
+        id: "determine-tag"
+        run: "echo \"::set-output name=tag::${GITHUB_REF#refs/tags/}\""
+
+      - name: 🚢 to TER
+        run: |
+          if [ -n "${{ secrets.TYPO3_ORG_USERNAME }}" ] && [ -n "${{ secrets.TYPO3_ORG_PASSWORD }}" ]; then
+            echo -e "Preparing upload of release ${{ steps.determine-tag.outputs.tag }} to TER\n";
+
+            # Install ter client
+            composer global require helhum/ter-client
+
+            echo "🧹 before we upload";
+            git clean -fx;
+            composer extension-cleanup-for-release;
+
+            # Upload
+            TAG_MESSAGE=`git tag -n10 -l ${{ steps.determine-tag.outputs.tag }} | sed 's/^[0-9.]*[ ]*//g'`
+            echo "Tag-Message: ${TAG_MESSAGE}"
+            echo "Uploading release ${{ steps.determine-tag.outputs.tag }} to TER"
+            $HOME/.composer/vendor/helhum/ter-client/ter-client upload crawler . -u "${{ secrets.TYPO3_ORG_USERNAME }}" -p "${{ secrets.TYPO3_ORG_PASSWORD }}" -m "$TAG_MESSAGE"
+          fi;

--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -43,5 +43,5 @@ jobs:
             TAG_MESSAGE=`git tag -n10 -l ${{ steps.determine-tag.outputs.tag }} | sed 's/^[0-9.]*[ ]*//g'`
             echo "Tag-Message: ${TAG_MESSAGE}"
             echo "Uploading release ${{ steps.determine-tag.outputs.tag }} to TER"
-            $HOME/.composer/vendor/helhum/ter-client/ter-client upload crawler . -u "${{ secrets.TYPO3_ORG_USERNAME }}" -p "${{ secrets.TYPO3_ORG_PASSWORD }}" -m "$TAG_MESSAGE"
+            $HOME/.composer/vendor/helhum/ter-client/ter-client upload ${{ secrets.EXTENSION_KEY }} . -u "${{ secrets.TYPO3_ORG_USERNAME }}" -p "${{ secrets.TYPO3_ORG_PASSWORD }}" -m "$TAG_MESSAGE"
           fi;

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -1,0 +1,53 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "**"
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
+    name: PHPstan
+    steps:
+      - uses: actions/checkout@v2
+      - id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer install --no-progress
+      - run: composer analyse
+
+  code-style:
+    name: Code Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.2
+          coverage: none
+      - run: composer install --no-progress
+      - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
-          coverage: none # disable xdebug, pcov
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up PHP Version
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -39,7 +39,6 @@ jobs:
         run: |
           composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
           git checkout composer.json
-          ln -nfs .Build/vendor/typo3/cms/typo3 typo3
 
       - name: Code Style
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
@@ -69,7 +68,6 @@ jobs:
           rm -rf composer.lock .Build
           composer require --dev nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
           git checkout composer.json
-          ln -nfs .Build/vendor/typo3/cms/typo3 typo3
           .Build/bin/phpunit --whitelist Classes --colors -c $UNIT_XML Tests/Unit
           .Build/bin/phpunit --whitelist Classes --colors -c $FUNCTIONAL_XML Tests/Functional
         if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -48,6 +48,7 @@ jobs:
           git checkout composer.json
 
       - name: Code Style
+        if: (matrix.typo3 != 'dev-master') || (matrix.typo3 == 'dev-master' && matrix.php == '7.4')
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -40,6 +40,13 @@ jobs:
           composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
           git checkout composer.json
 
+      - name: Install dependencies with nimut/typo3-complete:dev-master
+        if: matrix.typo3 == 'dev-master'
+        run: |
+          rm -rf composer.lock .Build
+          composer require --dev --no-progress nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
+          git checkout composer.json
+
       - name: Code Style
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
@@ -73,10 +80,6 @@ jobs:
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
           export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
-          composer remove --dev typo3/testing-framework rector/rector
-          rm -rf composer.lock .Build
-          composer require --dev nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
-          git checkout composer.json
           .Build/bin/phpunit --whitelist Classes --colors -c $UNIT_XML Tests/Unit
           .Build/bin/phpunit --whitelist Classes --colors -c $FUNCTIONAL_XML Tests/Functional
         if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -70,6 +70,7 @@ jobs:
           typo3DatabaseUsername: root
 
       - name: Tests for dev-master
+        continue-on-error: true
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
           export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -42,13 +42,19 @@ jobs:
 
       - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 7.4
         if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
+        continue-on-error: true
         run: |
           rm -rf composer.lock .Build
           composer require --dev --no-progress nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
           git checkout composer.json
 
       - name: Code Style
-        if: (matrix.typo3 != 'dev-master') || (matrix.typo3 == 'dev-master' && matrix.php == '7.4')
+        if: matrix.typo3 != 'dev-master'
+        run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
+
+      - name: Code Style for dev-master and PHP == 7.4
+        continue-on-error: true
+        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -47,14 +47,22 @@ jobs:
       - name: Unit tests
         if: matrix.typo3 != 'dev-master'
         run: |
-          export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
-          .Build/bin/phpunit --whitelist Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
+          if [ -d "Tests/Unit" ]; then
+            export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
+            .Build/bin/phpunit --whitelist Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
+          else
+            echo "No unit test files."
+          fi
 
       - name: Functional / integration tests
         if: matrix.typo3 != 'dev-master'
         run: |
-          export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
-          .Build/bin/phpunit --whitelist Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
+          if [ -d "Tests/Functional" ]; then
+            export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
+            .Build/bin/phpunit --whitelist Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
+          else
+            echo "No functional test files."
+          fi
         env:
           typo3DatabaseHost: 127.0.0.1
           typo3DatabaseName: typo3

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -40,8 +40,8 @@ jobs:
           composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
           git checkout composer.json
 
-      - name: Install dependencies with nimut/typo3-complete:dev-master
-        if: matrix.typo3 == 'dev-master'
+      - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 7.4
+        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
         run: |
           rm -rf composer.lock .Build
           composer require --dev --no-progress nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
@@ -75,14 +75,14 @@ jobs:
           typo3DatabasePassword: root
           typo3DatabaseUsername: root
 
-      - name: Tests for dev-master
+      - name: Tests for dev-master and PHP == 7.4
+        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
         continue-on-error: true
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
           export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
           .Build/bin/phpunit --whitelist Classes --colors -c $UNIT_XML Tests/Unit
           .Build/bin/phpunit --whitelist Classes --colors -c $FUNCTIONAL_XML Tests/Functional
-        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
         env:
           typo3DatabaseHost: 127.0.0.1
           typo3DatabaseName: typo3

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -12,6 +12,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php: [ '7.2', '7.3', '7.4' ]
         typo3: [ '^9.5', '^10.4', 'dev-master' ]

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1,0 +1,80 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4' ]
+        typo3: [ '^9.5', '^10.4', 'dev-master' ]
+
+    name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
+    steps:
+      - name: Start database server
+        run: sudo /etc/init.d/mysql start
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP Version
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: none # disable xdebug, pcov
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
+        if: matrix.typo3 != 'dev-master'
+        run: |
+          composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
+          git checkout composer.json
+          ln -nfs .Build/vendor/typo3/cms/typo3 typo3
+
+      - name: Code Style
+        run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
+
+      - name: Unit tests
+        if: matrix.typo3 != 'dev-master'
+        run: |
+          export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
+          .Build/bin/phpunit --whitelist Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
+
+      - name: Functional / integration tests
+        if: matrix.typo3 != 'dev-master'
+        run: |
+          export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
+          .Build/bin/phpunit --whitelist Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
+        env:
+          typo3DatabaseHost: 127.0.0.1
+          typo3DatabaseName: typo3
+          typo3DatabasePassword: root
+          typo3DatabaseUsername: root
+
+      - name: Tests for dev-master
+        run: |
+          export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
+          export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
+          composer remove --dev typo3/testing-framework rector/rector
+          rm -rf composer.lock .Build
+          composer require --dev nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
+          git checkout composer.json
+          ln -nfs .Build/vendor/typo3/cms/typo3 typo3
+          .Build/bin/phpunit --whitelist Classes --colors -c $UNIT_XML Tests/Unit
+          .Build/bin/phpunit --whitelist Classes --colors -c $FUNCTIONAL_XML Tests/Functional
+        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
+        env:
+          typo3DatabaseHost: 127.0.0.1
+          typo3DatabaseName: typo3
+          typo3DatabasePassword: root
+          typo3DatabaseUsername: root

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCS Coding Standards">
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="colors" />
+
+    <!-- Show progress of the run -->
+    <arg value="p"/>
+
+    <rule ref="PSR12"/>
+
+    <file>Classes</file>
+    <file>Configuration</file>
+    <file>Tests</file>
+</ruleset>

--- a/Classes/Domain/Model/Country.php
+++ b/Classes/Domain/Model/Country.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace SJBR\StaticInfoTables\Domain\Model;
 
 /***************************************************************
@@ -36,6 +39,7 @@ class Country extends AbstractEntity
 {
     /**
      * The French short name
+     *
      * @var string
      */
     protected $shortNameFr = '';

--- a/Classes/Domain/Model/CountryZone.php
+++ b/Classes/Domain/Model/CountryZone.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace SJBR\StaticInfoTables\Domain\Model;
 
 /***************************************************************
@@ -36,6 +39,7 @@ class CountryZone extends AbstractEntity
 {
     /**
      * French name of the country zone
+     *
      * @var string
      */
     protected $nameFr = '';
@@ -45,7 +49,7 @@ class CountryZone extends AbstractEntity
      *
      * @return string
      */
-    public function getNameFr()
+    public function getNameFr(): string
     {
         if ($this->nameFr === '') {
             return $this->getLocalName();
@@ -53,14 +57,7 @@ class CountryZone extends AbstractEntity
         return $this->nameFr;
     }
 
-    /**
-     * Sets the French name.
-     *
-     * @param string $nameFr
-     *
-     * @return void
-     */
-    public function setNameFr($nameFr)
+    public function setNameFr(string $nameFr): void
     {
         $this->nameFr = $nameFr;
     }

--- a/Classes/Domain/Model/Currency.php
+++ b/Classes/Domain/Model/Currency.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace SJBR\StaticInfoTables\Domain\Model;
 
 /***************************************************************
@@ -36,12 +39,14 @@ class Currency extends AbstractEntity
 {
     /**
      * French name of the currency
+     *
      * @var string
      */
     protected $nameFr = '';
 
     /**
      * French name of the currency subdivision unit
+     *
      * @var string
      */
     protected $subdivisionNameFr = '';

--- a/Classes/Domain/Model/Language.php
+++ b/Classes/Domain/Model/Language.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace SJBR\StaticInfoTables\Domain\Model;
 
 /***************************************************************
@@ -36,6 +39,7 @@ class Language extends AbstractEntity
 {
     /**
      * French name of the language
+     *
      * @var string
      */
     protected $nameFr = '';
@@ -45,7 +49,7 @@ class Language extends AbstractEntity
      *
      * @return string
      */
-    public function getNameFr()
+    public function getNameFr(): string
     {
         return $this->nameFr;
     }
@@ -53,11 +57,11 @@ class Language extends AbstractEntity
     /**
      * Sets the French name of the language
      *
-     * @param string $nameFrench
+     * @param string $nameFr
      *
      * @return void
      */
-    public function setNameFr($nameFr)
+    public function setNameFr(string $nameFr): void
     {
         $this->nameFr = $nameFr;
     }

--- a/Classes/Domain/Model/Territory.php
+++ b/Classes/Domain/Model/Territory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace SJBR\StaticInfoTables\Domain\Model;
 
 /***************************************************************
@@ -36,6 +39,7 @@ class Territory extends AbstractEntity
 {
     /**
      * French name of the territory
+     *
      * @var string
      */
     protected $nameFr = '';

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mselbach\StaticInfoTablesFr;
 
 /***************************************************************
@@ -30,8 +32,5 @@ namespace Mselbach\StaticInfoTablesFr;
 
 class Extension
 {
-    /**
-     * @var string The extension key
-     */
-    const EXTENSION_KEY = 'static_info_tables_fr';
+    public const EXTENSION_KEY = 'static_info_tables_fr';
 }

--- a/Classes/Provider/TcaProvider.php
+++ b/Classes/Provider/TcaProvider.php
@@ -1,6 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mselbach\StaticInfoTablesFr\Provider;
+
+use Mselbach\StaticInfoTablesFr\Extension;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 /***************************************************************
  *  Copyright notice
@@ -27,10 +32,6 @@ namespace Mselbach\StaticInfoTablesFr\Provider;
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-
-use Mselbach\StaticInfoTablesFr\Extension;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
 class TcaProvider
 {
     /**
@@ -39,10 +40,10 @@ class TcaProvider
     protected static $LL = 'LLL:EXT:%s/Resources/Private/Language/locallang_db.xlf:%s_item.%s';
 
     /**
-     * @param $additionalFields
-     * @param $dataSetName
+     * @param array  $additionalFields
+     * @param string $dataSetName
      */
-    public static function generateAndRegisterTca($additionalFields, $dataSetName)
+    public static function generateAndRegisterTca(array $additionalFields, string $dataSetName): void
     {
         foreach ($additionalFields as $sourceField => $destField) {
             $additionalColumns = [];

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 return [

--- a/Configuration/TCA/Overrides/static_countries.php
+++ b/Configuration/TCA/Overrides/static_countries.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 defined('TYPO3_MODE') || die();
 
-$initialize = function ($dataSetName) {
+(static function (string $dataSetName) {
     $additionalFields = [
         'cn_short_en' => 'cn_short_fr'
     ];
@@ -10,6 +13,4 @@ $initialize = function ($dataSetName) {
         $additionalFields,
         $dataSetName
     );
-};
-$initialize('static_countries');
-unset($initialize);
+})('static_countries');

--- a/Configuration/TCA/Overrides/static_country_zones.php
+++ b/Configuration/TCA/Overrides/static_country_zones.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 defined('TYPO3_MODE') || die();
 
-$initialize = function ($dataSetName) {
+(static function (string $dataSetName) {
     $additionalFields = [
         'zn_name_en' => 'zn_name_fr'
     ];
@@ -10,6 +13,4 @@ $initialize = function ($dataSetName) {
         $additionalFields,
         $dataSetName
     );
-};
-$initialize('static_country_zones');
-unset($initialize);
+})('static_country_zones');

--- a/Configuration/TCA/Overrides/static_currencies.php
+++ b/Configuration/TCA/Overrides/static_currencies.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 defined('TYPO3_MODE') || die();
 
-$initialize = function ($dataSetName) {
+(static function (string $dataSetName) {
     $additionalFields = [
         'cu_name_en' => 'cu_name_fr',
         'cu_sub_name_en' => 'cu_sub_name_fr'
@@ -11,6 +14,4 @@ $initialize = function ($dataSetName) {
         $additionalFields,
         $dataSetName
     );
-};
-$initialize('static_currencies');
-unset($initialize);
+})('static_currencies');

--- a/Configuration/TCA/Overrides/static_languages.php
+++ b/Configuration/TCA/Overrides/static_languages.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 defined('TYPO3_MODE') || die();
 
-$initialize = function ($dataSetName) {
+(static function (string $dataSetName) {
     $additionalFields = [
         'lg_name_en' => 'lg_name_fr'
     ];
@@ -10,6 +13,4 @@ $initialize = function ($dataSetName) {
         $additionalFields,
         $dataSetName
     );
-};
-$initialize('static_languages');
-unset($initialize);
+})('static_languages');

--- a/Configuration/TCA/Overrides/static_territories.php
+++ b/Configuration/TCA/Overrides/static_territories.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 defined('TYPO3_MODE') || die();
 
-$initialize = function ($dataSetName) {
+(static function (string $dataSetName) {
     $additionalFields = [
         'tr_name_en' => 'tr_name_fr'
     ];
@@ -10,6 +13,4 @@ $initialize = function ($dataSetName) {
         $additionalFields,
         $dataSetName
     );
-};
-$initialize('static_territories');
-unset($initialize);
+})('static_territories');

--- a/Tests/Unit/Domain/Model/CountryTest.php
+++ b/Tests/Unit/Domain/Model/CountryTest.php
@@ -1,18 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mselbach\StaticInfoTablesFr\Tests\Unit\Domain\Model;
 
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
-/**
- * CountryTest
- */
 class CountryTest extends UnitTestCase
 {
     /**
      * @test
      */
-    public function testDummy()
+    public function testDummy(): void
     {
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8",
-    "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0"
+    "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0",
+    "phpstan/extension-installer": "^1.0",
+    "phpstan/phpstan": "^0.12.67",
+    "phpstan/phpstan-deprecation-rules": "^0.12.5",
+    "saschaegerer/phpstan-typo3": "^0.13.1"
   },
   "autoload": {
     "psr-4": {
@@ -57,6 +61,10 @@
     "post-autoload-dump": [
       "mkdir -p .Build/public/typo3conf/ext/",
       "[ -L .Build/public/typo3conf/ext/static_info_tables_fr ] || ln -snvf ../../../../. .Build/public/typo3conf/ext/static_info_tables_fr"
+    ],
+    "analyse": [
+      "[ -e .Build/bin/phpstan ] || composer update",
+      ".Build/bin/phpstan analyse"
     ],
     "extension-cleanup-for-release": [
       "rm -rf Tests/",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": ">=7.2",
-    "typo3/cms-core": "^9.5 || ^10.4",
+    "typo3/cms-core": "^9.5 || ^10.4 || ^11.0 || dev-master",
     "sjbr/static-info-tables": "^6.9"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
   "description": "French (fr) language pack for the Static Info Tables providing localized names for countries, currencies and so on.",
   "type": "typo3-cms-extension",
   "license": "GPL-2.0-or-later",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "authors": [
     {
       "name": "Manuel Selbach",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",
-    "squizlabs/php_codesniffer": "^2.8",
+    "squizlabs/php_codesniffer": "^3.5",
     "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "^0.12.67",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "sjbr/static-info-tables": "^6.9"
   },
   "require-dev": {
+    "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^2.8",
     "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev || ^5.0",
     "phpstan/extension-installer": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,33 @@
+parameters:
+    level: max
+    paths:
+        - "Classes/"
+        - "Configuration/"
+        - "Tests/"
+    checkMissingIterableValueType: false
+
+    ignoreErrors:
+        -
+            message: "#^Right side of || is always false\\.$#"
+            count: 1
+            path: Configuration/TCA/Overrides/static_countries.php
+        -
+            message: "#^Right side of || is always false\\.$#"
+            count: 1
+            path: Configuration/TCA/Overrides/static_country_zones.php
+        -
+            message: "#^Right side of || is always false\\.$#"
+            count: 1
+            path: Configuration/TCA/Overrides/static_currencies.php
+        -
+            message: "#^Right side of || is always false\\.$#"
+            count: 1
+            path: Configuration/TCA/Overrides/static_languages.php
+        -
+            message: "#^Right side of || is always false\\.$#"
+            count: 1
+            path: Configuration/TCA/Overrides/static_territories.php
+        -
+            message: "#^Call to an undefined method SJBR\\\\StaticInfoTables\\\\Domain\\\\Model\\\\CountryZone::getLocalName\\(\\)\\.$#"
+            count: 1
+            path: Classes/Domain/Model/CountryZone.php


### PR DESCRIPTION
With this PR the main goal is to move the current implementation of CI on travis-ci.org to GitHub actions.

Furthermore some adaptions have been taken place:

- Use of PSR-12
- Integration of PHPStan
- Update code according to CGL and PHPStan findings
- validate composer.json