### PR TITLE
Compatibilty for TYPO3 v12

### DIFF
--- a/.github/workflows/Deploy.yaml
+++ b/.github/workflows/Deploy.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
       - name: Install tailor

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4' ]
+        php: [ '8.1' ]
     name: PHPstan
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,11 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           coverage: none
+
+      - name: Allow composer plugin typo3/cms-composer-installers
+        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
+
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Allow composer plugin typo3/class-alias-loader
         run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
 
+      - name: Allow composer plugin phpstan/extension-installer
+        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
+
       - run: composer install --no-progress
       - run: composer analyse
 
@@ -62,6 +65,9 @@ jobs:
 
       - name: Allow composer plugin typo3/class-alias-loader
         run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
+
+      - name: Allow composer plugin phpstan/extension-installer
+        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
 
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Allow composer plugin typo3/cms-composer-installers
         run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
 
+      - name: Allow composer plugin typo3/class-alias-loader
+        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
+
       - run: composer install --no-progress
       - run: composer analyse
 
@@ -56,6 +59,9 @@ jobs:
 
       - name: Allow composer plugin typo3/cms-composer-installers
         run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
+
+      - name: Allow composer plugin typo3/class-alias-loader
+        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
 
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: none
+
+      - name: Allow composer plugin typo3/cms-composer-installers
+        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
+
       - run: composer install --no-progress
       - run: composer analyse
 

--- a/.github/workflows/StaticAnalysis.yaml
+++ b/.github/workflows/StaticAnalysis.yaml
@@ -30,15 +30,6 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - name: Allow composer plugin typo3/cms-composer-installers
-        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
-
-      - name: Allow composer plugin typo3/class-alias-loader
-        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
-
-      - name: Allow composer plugin phpstan/extension-installer
-        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
-
       - run: composer install --no-progress
       - run: composer analyse
 
@@ -59,15 +50,6 @@ jobs:
         with:
           php-version: 8.1
           coverage: none
-
-      - name: Allow composer plugin typo3/cms-composer-installers
-        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
-
-      - name: Allow composer plugin typo3/class-alias-loader
-        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
-
-      - name: Allow composer plugin phpstan/extension-installer
-        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
 
       - run: composer install --no-progress
       - run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -40,6 +40,9 @@ jobs:
       - name: Allow composer plugin typo3/class-alias-loader
         run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
 
+      - name: Allow composer plugin phpstan/extension-installer
+        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
+
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
         if: matrix.typo3 != 'dev-master'
         run: |

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1' ]
-        typo3: [ '^12.4', 'dev-main' ]
+        php: [ '8.1', '8.2' ]
+        typo3: [ '^12.4' ]
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:
@@ -32,38 +32,12 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Allow composer plugin typo3/cms-composer-installers
-        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
-
-      - name: Allow composer plugin typo3/class-alias-loader
-        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
-
-      - name: Allow composer plugin phpstan/extension-installer
-        run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
-
-      - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
-        if: matrix.typo3 != 'dev-main'
+      - name: Install full TYPO3 in version ${{ matrix.typo3 }}
         run: |
           composer require --no-progress "typo3/cms-adminpanel:${{ matrix.typo3 }}" "typo3/cms-backend:${{ matrix.typo3 }}" "typo3/cms-belog:${{ matrix.typo3 }}" "typo3/cms-beuser:${{ matrix.typo3 }}" "typo3/cms-core:${{ matrix.typo3 }}" "typo3/cms-dashboard:${{ matrix.typo3 }}" "typo3/cms-extbase:${{ matrix.typo3 }}" "typo3/cms-extensionmanager:${{ matrix.typo3 }}" "typo3/cms-felogin:${{ matrix.typo3 }}" "typo3/cms-filelist:${{ matrix.typo3 }}" "typo3/cms-filemetadata:${{ matrix.typo3 }}" "typo3/cms-fluid:${{ matrix.typo3 }}" "typo3/cms-fluid-styled-content:${{ matrix.typo3 }}" "typo3/cms-form:${{ matrix.typo3 }}" "typo3/cms-frontend:${{ matrix.typo3 }}" "typo3/cms-impexp:${{ matrix.typo3 }}" "typo3/cms-indexed-search:${{ matrix.typo3 }}" "typo3/cms-info:${{ matrix.typo3 }}" "typo3/cms-install:${{ matrix.typo3 }}" "typo3/cms-linkvalidator:${{ matrix.typo3 }}" "typo3/cms-lowlevel:${{ matrix.typo3 }}" "typo3/cms-opendocs:${{ matrix.typo3 }}" "typo3/cms-reactions:${{ matrix.typo3 }}" "typo3/cms-recycler:${{ matrix.typo3 }}" "typo3/cms-redirects:${{ matrix.typo3 }}" "typo3/cms-reports:${{ matrix.typo3 }}" "typo3/cms-rte-ckeditor:${{ matrix.typo3 }}" "typo3/cms-scheduler:${{ matrix.typo3 }}" "typo3/cms-seo:${{ matrix.typo3 }}" "typo3/cms-setup:${{ matrix.typo3 }}" "typo3/cms-sys-note:${{ matrix.typo3 }}" "typo3/cms-t3editor:${{ matrix.typo3 }}" "typo3/cms-tstemplate:${{ matrix.typo3 }}" "typo3/cms-viewpage:${{ matrix.typo3 }}" "typo3/cms-webhooks:${{ matrix.typo3 }}" "typo3/cms-workspaces:${{ matrix.typo3 }}" "typo3/minimal:^12"
-          
-          git checkout composer.json
-
-      - name: Install dependencies with nimut/typo3-complete:dev-main and PHP == 8.1
-        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
-        continue-on-error: true
-        run: |
-          rm -rf composer.lock .Build
-          composer require --no-progress "typo3/cms-adminpanel:${{ matrix.typo3 }}" "typo3/cms-backend:${{ matrix.typo3 }}" "typo3/cms-belog:${{ matrix.typo3 }}" "typo3/cms-beuser:${{ matrix.typo3 }}" "typo3/cms-core:${{ matrix.typo3 }}" "typo3/cms-dashboard:${{ matrix.typo3 }}" "typo3/cms-extbase:${{ matrix.typo3 }}" "typo3/cms-extensionmanager:${{ matrix.typo3 }}" "typo3/cms-felogin:${{ matrix.typo3 }}" "typo3/cms-filelist:${{ matrix.typo3 }}" "typo3/cms-filemetadata:${{ matrix.typo3 }}" "typo3/cms-fluid:${{ matrix.typo3 }}" "typo3/cms-fluid-styled-content:${{ matrix.typo3 }}" "typo3/cms-form:${{ matrix.typo3 }}" "typo3/cms-frontend:${{ matrix.typo3 }}" "typo3/cms-impexp:${{ matrix.typo3 }}" "typo3/cms-indexed-search:${{ matrix.typo3 }}" "typo3/cms-info:${{ matrix.typo3 }}" "typo3/cms-install:${{ matrix.typo3 }}" "typo3/cms-linkvalidator:${{ matrix.typo3 }}" "typo3/cms-lowlevel:${{ matrix.typo3 }}" "typo3/cms-opendocs:${{ matrix.typo3 }}" "typo3/cms-reactions:${{ matrix.typo3 }}" "typo3/cms-recycler:${{ matrix.typo3 }}" "typo3/cms-redirects:${{ matrix.typo3 }}" "typo3/cms-reports:${{ matrix.typo3 }}" "typo3/cms-rte-ckeditor:${{ matrix.typo3 }}" "typo3/cms-scheduler:${{ matrix.typo3 }}" "typo3/cms-seo:${{ matrix.typo3 }}" "typo3/cms-setup:${{ matrix.typo3 }}" "typo3/cms-sys-note:${{ matrix.typo3 }}" "typo3/cms-t3editor:${{ matrix.typo3 }}" "typo3/cms-tstemplate:${{ matrix.typo3 }}" "typo3/cms-viewpage:${{ matrix.typo3 }}" "typo3/cms-webhooks:${{ matrix.typo3 }}" "typo3/cms-workspaces:${{ matrix.typo3 }}" "typo3/minimal:${{ matrix.typo3 }}"
-          composer require --dev --no-progress saschaegerer/phpstan-typo3:"*" typo3/testing-framework:"*"
           git checkout composer.json
 
       - name: Code Style
-        if: matrix.typo3 != 'dev-main'
-        run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
-
-      - name: Code Style for dev-main and PHP == 8.1
-        continue-on-error: true
-        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -67,13 +67,13 @@ jobs:
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
-        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
 
       - name: Functional tests with mariadb
-        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
       - name: Functional tests with postgres
-        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
       - name: Functional tests with sqlite
-        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
+        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           rm -rf composer.lock .Build
           composer require --no-progress "typo3/cms-adminpanel:${{ matrix.typo3 }}" "typo3/cms-backend:${{ matrix.typo3 }}" "typo3/cms-belog:${{ matrix.typo3 }}" "typo3/cms-beuser:${{ matrix.typo3 }}" "typo3/cms-core:${{ matrix.typo3 }}" "typo3/cms-dashboard:${{ matrix.typo3 }}" "typo3/cms-extbase:${{ matrix.typo3 }}" "typo3/cms-extensionmanager:${{ matrix.typo3 }}" "typo3/cms-felogin:${{ matrix.typo3 }}" "typo3/cms-filelist:${{ matrix.typo3 }}" "typo3/cms-filemetadata:${{ matrix.typo3 }}" "typo3/cms-fluid:${{ matrix.typo3 }}" "typo3/cms-fluid-styled-content:${{ matrix.typo3 }}" "typo3/cms-form:${{ matrix.typo3 }}" "typo3/cms-frontend:${{ matrix.typo3 }}" "typo3/cms-impexp:${{ matrix.typo3 }}" "typo3/cms-indexed-search:${{ matrix.typo3 }}" "typo3/cms-info:${{ matrix.typo3 }}" "typo3/cms-install:${{ matrix.typo3 }}" "typo3/cms-linkvalidator:${{ matrix.typo3 }}" "typo3/cms-lowlevel:${{ matrix.typo3 }}" "typo3/cms-opendocs:${{ matrix.typo3 }}" "typo3/cms-reactions:${{ matrix.typo3 }}" "typo3/cms-recycler:${{ matrix.typo3 }}" "typo3/cms-redirects:${{ matrix.typo3 }}" "typo3/cms-reports:${{ matrix.typo3 }}" "typo3/cms-rte-ckeditor:${{ matrix.typo3 }}" "typo3/cms-scheduler:${{ matrix.typo3 }}" "typo3/cms-seo:${{ matrix.typo3 }}" "typo3/cms-setup:${{ matrix.typo3 }}" "typo3/cms-sys-note:${{ matrix.typo3 }}" "typo3/cms-t3editor:${{ matrix.typo3 }}" "typo3/cms-tstemplate:${{ matrix.typo3 }}" "typo3/cms-viewpage:${{ matrix.typo3 }}" "typo3/cms-webhooks:${{ matrix.typo3 }}" "typo3/cms-workspaces:${{ matrix.typo3 }}" "typo3/minimal:${{ matrix.typo3 }}"
-          composer require --dev --no-progress saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
+          composer require --dev --no-progress saschaegerer/phpstan-typo3:"*" typo3/testing-framework:"*"
           git checkout composer.json
 
       - name: Code Style
@@ -72,7 +72,7 @@ jobs:
         if: matrix.typo3 != 'dev-main'
         run: |
           if [ -d "Tests/Unit" ]; then
-            export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
+            export "UNIT_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml
             .Build/bin/phpunit Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
           else
             echo "No unit test files."
@@ -82,7 +82,7 @@ jobs:
         if: matrix.typo3 != 'dev-main'
         run: |
           if [ -d "Tests/Functional" ]; then
-            export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
+            export "FUNCTIONAL_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml
             .Build/bin/phpunit Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
           else
             echo "No functional test files."

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Allow composer plugin typo3/cms-composer-installers
         run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
 
+      - name: Allow composer plugin typo3/class-alias-loader
+        run: composer config --no-plugins allow-plugins.typo3/class-alias-loader true
+
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
         if: matrix.typo3 != 'dev-master'
         run: |

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4' ]
-        typo3: [ '^11.5', 'dev-master' ]
+        php: [ '8.1' ]
+        typo3: [ '^12.4', 'dev-master' ]
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:
@@ -34,14 +34,17 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
+      - name: Allow composer plugin typo3/cms-composer-installers
+        run: composer config --no-plugins allow-plugins.typo3/cms-composer-installers true
+
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
         if: matrix.typo3 != 'dev-master'
         run: |
           composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
           git checkout composer.json
 
-      - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 7.4
-        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
+      - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 8.1
+        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
         continue-on-error: true
         run: |
           rm -rf composer.lock .Build
@@ -52,9 +55,9 @@ jobs:
         if: matrix.typo3 != 'dev-master'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
-      - name: Code Style for dev-master and PHP == 7.4
+      - name: Code Style for dev-master and PHP == 8.1
         continue-on-error: true
-        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
+        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
@@ -82,8 +85,8 @@ jobs:
           typo3DatabasePassword: root
           typo3DatabaseUsername: root
 
-      - name: Tests for dev-master and PHP == 7.4
-        if: matrix.typo3 == 'dev-master' && matrix.php == '7.4'
+      - name: Tests for dev-master and PHP == 8.1
+        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
         continue-on-error: true
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
         if: matrix.typo3 != 'dev-master'
         run: |
-          composer require --dev nimut/typo3-complete:${{ matrix.typo3 }} --no-progress
+          composer require --dev nimut/typo3-complete:"12.0.x-dev" --no-progress
           git checkout composer.json
 
       - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 8.1

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -46,7 +46,8 @@ jobs:
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
         if: matrix.typo3 != 'dev-main'
         run: |
-          composer require --dev nimut/typo3-complete:"12.0.x-dev" --no-progress
+          composer require --no-progress "typo3/cms-adminpanel:${{ matrix.typo3 }}" "typo3/cms-backend:${{ matrix.typo3 }}" "typo3/cms-belog:${{ matrix.typo3 }}" "typo3/cms-beuser:${{ matrix.typo3 }}" "typo3/cms-core:${{ matrix.typo3 }}" "typo3/cms-dashboard:${{ matrix.typo3 }}" "typo3/cms-extbase:${{ matrix.typo3 }}" "typo3/cms-extensionmanager:${{ matrix.typo3 }}" "typo3/cms-felogin:${{ matrix.typo3 }}" "typo3/cms-filelist:${{ matrix.typo3 }}" "typo3/cms-filemetadata:${{ matrix.typo3 }}" "typo3/cms-fluid:${{ matrix.typo3 }}" "typo3/cms-fluid-styled-content:${{ matrix.typo3 }}" "typo3/cms-form:${{ matrix.typo3 }}" "typo3/cms-frontend:${{ matrix.typo3 }}" "typo3/cms-impexp:${{ matrix.typo3 }}" "typo3/cms-indexed-search:${{ matrix.typo3 }}" "typo3/cms-info:${{ matrix.typo3 }}" "typo3/cms-install:${{ matrix.typo3 }}" "typo3/cms-linkvalidator:${{ matrix.typo3 }}" "typo3/cms-lowlevel:${{ matrix.typo3 }}" "typo3/cms-opendocs:${{ matrix.typo3 }}" "typo3/cms-reactions:${{ matrix.typo3 }}" "typo3/cms-recycler:${{ matrix.typo3 }}" "typo3/cms-redirects:${{ matrix.typo3 }}" "typo3/cms-reports:${{ matrix.typo3 }}" "typo3/cms-rte-ckeditor:${{ matrix.typo3 }}" "typo3/cms-scheduler:${{ matrix.typo3 }}" "typo3/cms-seo:${{ matrix.typo3 }}" "typo3/cms-setup:${{ matrix.typo3 }}" "typo3/cms-sys-note:${{ matrix.typo3 }}" "typo3/cms-t3editor:${{ matrix.typo3 }}" "typo3/cms-tstemplate:${{ matrix.typo3 }}" "typo3/cms-viewpage:${{ matrix.typo3 }}" "typo3/cms-webhooks:${{ matrix.typo3 }}" "typo3/cms-workspaces:${{ matrix.typo3 }}" "typo3/minimal:^12"
+          
           git checkout composer.json
 
       - name: Install dependencies with nimut/typo3-complete:dev-main and PHP == 8.1
@@ -54,7 +55,8 @@ jobs:
         continue-on-error: true
         run: |
           rm -rf composer.lock .Build
-          composer require --dev --no-progress nimut/typo3-complete:dev-main saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
+          composer require --no-progress "typo3/cms-adminpanel:${{ matrix.typo3 }}" "typo3/cms-backend:${{ matrix.typo3 }}" "typo3/cms-belog:${{ matrix.typo3 }}" "typo3/cms-beuser:${{ matrix.typo3 }}" "typo3/cms-core:${{ matrix.typo3 }}" "typo3/cms-dashboard:${{ matrix.typo3 }}" "typo3/cms-extbase:${{ matrix.typo3 }}" "typo3/cms-extensionmanager:${{ matrix.typo3 }}" "typo3/cms-felogin:${{ matrix.typo3 }}" "typo3/cms-filelist:${{ matrix.typo3 }}" "typo3/cms-filemetadata:${{ matrix.typo3 }}" "typo3/cms-fluid:${{ matrix.typo3 }}" "typo3/cms-fluid-styled-content:${{ matrix.typo3 }}" "typo3/cms-form:${{ matrix.typo3 }}" "typo3/cms-frontend:${{ matrix.typo3 }}" "typo3/cms-impexp:${{ matrix.typo3 }}" "typo3/cms-indexed-search:${{ matrix.typo3 }}" "typo3/cms-info:${{ matrix.typo3 }}" "typo3/cms-install:${{ matrix.typo3 }}" "typo3/cms-linkvalidator:${{ matrix.typo3 }}" "typo3/cms-lowlevel:${{ matrix.typo3 }}" "typo3/cms-opendocs:${{ matrix.typo3 }}" "typo3/cms-reactions:${{ matrix.typo3 }}" "typo3/cms-recycler:${{ matrix.typo3 }}" "typo3/cms-redirects:${{ matrix.typo3 }}" "typo3/cms-reports:${{ matrix.typo3 }}" "typo3/cms-rte-ckeditor:${{ matrix.typo3 }}" "typo3/cms-scheduler:${{ matrix.typo3 }}" "typo3/cms-seo:${{ matrix.typo3 }}" "typo3/cms-setup:${{ matrix.typo3 }}" "typo3/cms-sys-note:${{ matrix.typo3 }}" "typo3/cms-t3editor:${{ matrix.typo3 }}" "typo3/cms-tstemplate:${{ matrix.typo3 }}" "typo3/cms-viewpage:${{ matrix.typo3 }}" "typo3/cms-webhooks:${{ matrix.typo3 }}" "typo3/cms-workspaces:${{ matrix.typo3 }}" "typo3/minimal:${{ matrix.typo3 }}"
+          composer require --dev --no-progress saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
           git checkout composer.json
 
       - name: Code Style

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -67,13 +67,13 @@ jobs:
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
 
       - name: Functional tests with mariadb
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
       - name: Functional tests with postgres
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
       - name: Functional tests with sqlite
-        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
+        run: .Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -19,8 +19,6 @@ jobs:
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:
-      - name: Start database server
-        run: sudo /etc/init.d/mysql start
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,40 +67,13 @@ jobs:
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
-        if: matrix.typo3 != 'dev-main'
-        run: |
-          if [ -d "Tests/Unit" ]; then
-            export "UNIT_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml
-            .Build/bin/phpunit Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
-          else
-            echo "No unit test files."
-          fi
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
 
-      - name: Functional / integration tests
-        if: matrix.typo3 != 'dev-main'
-        run: |
-          if [ -d "Tests/Functional" ]; then
-            export "FUNCTIONAL_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml
-            .Build/bin/phpunit Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
-          else
-            echo "No functional test files."
-          fi
-        env:
-          typo3DatabaseHost: 127.0.0.1
-          typo3DatabaseName: typo3
-          typo3DatabasePassword: root
-          typo3DatabaseUsername: root
+      - name: Functional tests with mariadb
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
-      - name: Tests for dev-main and PHP == 8.1
-        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
-        continue-on-error: true
-        run: |
-          export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
-          export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
-          .Build/bin/phpunit Classes --colors -c $UNIT_XML Tests/Unit
-          .Build/bin/phpunit Classes --colors -c $FUNCTIONAL_XML Tests/Functional
-        env:
-          typo3DatabaseHost: 127.0.0.1
-          typo3DatabaseName: typo3
-          typo3DatabasePassword: root
-          typo3DatabaseUsername: root
+      - name: Functional tests with postgres
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+
+      - name: Functional tests with sqlite
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -67,13 +67,13 @@ jobs:
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
-        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
 
       - name: Functional tests with mariadb
-        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
       - name: Functional tests with postgres
-        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
       - name: Functional tests with sqlite
-        run: .Build/vendor/typo3/testing-framework/Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.1' ]
-        typo3: [ '^12.4', 'dev-master' ]
+        typo3: [ '^12.4', 'dev-main' ]
 
     name: PHP ${{ matrix.php }}, TYPO3 ${{ matrix.typo3 }} tests
     steps:
@@ -44,30 +44,30 @@ jobs:
         run: composer config --no-plugins allow-plugins.phpstan/extension-installer true
 
       - name: Install dependencies with nimut/typo3-complete:${{ matrix.typo3 }}
-        if: matrix.typo3 != 'dev-master'
+        if: matrix.typo3 != 'dev-main'
         run: |
           composer require --dev nimut/typo3-complete:"12.0.x-dev" --no-progress
           git checkout composer.json
 
-      - name: Install dependencies with nimut/typo3-complete:dev-master and PHP == 8.1
-        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
+      - name: Install dependencies with nimut/typo3-complete:dev-main and PHP == 8.1
+        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
         continue-on-error: true
         run: |
           rm -rf composer.lock .Build
-          composer require --dev --no-progress nimut/typo3-complete:dev-master saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
+          composer require --dev --no-progress nimut/typo3-complete:dev-main saschaegerer/phpstan-typo3:"*" nimut/testing-framework:"*"
           git checkout composer.json
 
       - name: Code Style
-        if: matrix.typo3 != 'dev-master'
+        if: matrix.typo3 != 'dev-main'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
-      - name: Code Style for dev-master and PHP == 8.1
+      - name: Code Style for dev-main and PHP == 8.1
         continue-on-error: true
-        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
+        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
         run: .Build/bin/phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Unit tests
-        if: matrix.typo3 != 'dev-master'
+        if: matrix.typo3 != 'dev-main'
         run: |
           if [ -d "Tests/Unit" ]; then
             export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Functional / integration tests
-        if: matrix.typo3 != 'dev-master'
+        if: matrix.typo3 != 'dev-main'
         run: |
           if [ -d "Tests/Functional" ]; then
             export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
@@ -91,8 +91,8 @@ jobs:
           typo3DatabasePassword: root
           typo3DatabaseUsername: root
 
-      - name: Tests for dev-master and PHP == 8.1
-        if: matrix.typo3 == 'dev-master' && matrix.php == '8.1'
+      - name: Tests for dev-main and PHP == 8.1
+        if: matrix.typo3 == 'dev-main' && matrix.php == '8.1'
         continue-on-error: true
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           if [ -d "Tests/Unit" ]; then
             export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
-            .Build/bin/phpunit --whitelist Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
+            .Build/bin/phpunit Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit
           else
             echo "No unit test files."
           fi
@@ -83,7 +83,7 @@ jobs:
         run: |
           if [ -d "Tests/Functional" ]; then
             export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
-            .Build/bin/phpunit --whitelist Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
+            .Build/bin/phpunit Classes --coverage-clover=functional-coverage.clover --colors -c $FUNCTIONAL_XML Tests/Functional
           else
             echo "No functional test files."
           fi
@@ -99,8 +99,8 @@ jobs:
         run: |
           export "FUNCTIONAL_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/FunctionalTests.xml
           export "UNIT_XML"=.Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml
-          .Build/bin/phpunit --whitelist Classes --colors -c $UNIT_XML Tests/Unit
-          .Build/bin/phpunit --whitelist Classes --colors -c $FUNCTIONAL_XML Tests/Functional
+          .Build/bin/phpunit Classes --colors -c $UNIT_XML Tests/Unit
+          .Build/bin/phpunit Classes --colors -c $FUNCTIONAL_XML Tests/Functional
         env:
           typo3DatabaseHost: 127.0.0.1
           typo3DatabaseName: typo3

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" backupGlobals="true" bootstrap="FunctionalTestsBootstrap.php" cacheResult="false" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="false" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false">
+  <testsuites>
+    <testsuite name="Functional tests">
+      <directory>../Tests/Functional/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <const name="TYPO3_MODE" value="BE"/>
+    <ini name="display_errors" value="1"/>
+    <env name="TYPO3_CONTEXT" value="Testing"/>
+  </php>
+</phpunit>

--- a/Build/FunctionalTestsBootstrap.php
+++ b/Build/FunctionalTestsBootstrap.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+call_user_func(function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase->defineOriginalRootPath();
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+});

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+
+#
+# TYPO3 core test runner based on docker and docker-compose.
+#
+
+# Function to write a .env file in Build/testing-docker/local
+# This is read by docker-compose and vars defined here are
+# used in Build/testing-docker/local/docker-compose.yml
+setUpDockerComposeDotEnv() {
+    # Delete possibly existing local .env file if exists
+    [ -e .env ] && rm .env
+    # Set up a new .env file for docker-compose
+    echo "COMPOSE_PROJECT_NAME=local" >> .env
+    # To prevent access rights of files created by the testing, the docker image later
+    # runs with the same user that is currently executing the script. docker-compose can't
+    # use $UID directly itself since it is a shell variable and not an env variable, so
+    # we have to set it explicitly here.
+    echo "HOST_UID=`id -u`" >> .env
+    # Your local home directory for composer and npm caching
+    echo "HOST_HOME=${HOME}" >> .env
+    # Your local user
+    echo "ROOT_DIR"=${ROOT_DIR} >> .env
+    echo "HOST_USER=${USER}" >> .env
+    echo "TEST_FILE=${TEST_FILE}" >> .env
+    echo "TYPO3_VERSION=${TYPO3_VERSION}" >> .env
+    echo "PHP_XDEBUG_ON=${PHP_XDEBUG_ON}" >> .env
+    echo "PHP_XDEBUG_PORT=${PHP_XDEBUG_PORT}" >> .env
+    echo "PHP_VERSION=${PHP_VERSION}" >> .env
+    echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}" >> .env
+    echo "EXTRA_TEST_OPTIONS=${EXTRA_TEST_OPTIONS}" >> .env
+    echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}" >> .env
+}
+
+# Load help text into $HELP
+read -r -d '' HELP <<EOF
+enetcache test runner. Execute unit test suite and some other details.
+Also used by github actions for test execution.
+
+Usage: $0 [options] [file]
+
+No arguments: Run all unit tests with PHP 7.4
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - composerUpdate: "composer update"
+            - clean: clean up build and testing related files
+            - lint: PHP linting
+            - unit (default): PHP unit tests
+            - functional: functional tests
+
+    -d <mariadb|postgres|sqlite>
+        Only with -s functional
+        Specifies on which DBMS tests are performed
+            - mariadb (default): use mariadb
+            - postgres: use postgres
+            - sqlite: use sqlite
+
+    -p <7.4|8.0|8.1|8.2>
+        Specifies the PHP minor version to be used
+            - 7.4: (default) use PHP 7.4
+            - 8.0: use PHP 8.0
+            - 8.1: use PHP 8.1
+            - 8.2: use PHP 8.2
+
+    -t <11|12>
+        Only with -s composerUpdate
+        Specifies the TYPO3 core major version to be used
+            - 11: (default) use TYPO3 core v11
+            - 12: use TYPO3 core v12
+
+    -e "<phpunit options>"
+        Only with -s functional|unit
+        Additional options to send to phpunit tests.
+        For phpunit, options starting with "--" must be added after options starting with "-".
+        Example -e "-v --filter canRetrieveValueWithGP" to enable verbose output AND filter tests
+        named "canRetrieveValueWithGP"
+
+    -x
+        Only with -s unit
+        Send information to host instance for test or system under test break points. This is especially
+        useful if a local PhpStorm instance is listening on default xdebug port 9003. A different port
+        can be selected with -y
+
+    -y <port>
+        Send xdebug information to a different port than default 9003 if an IDE like PhpStorm
+        is not listening on default port.
+
+    -u
+        Update existing typo3gmbh/phpXY:latest docker images. Maintenance call to docker pull latest
+        versions of the main php images. The images are updated once in a while and only the youngest
+        ones are supported by core testing. Use this if weird test errors occur. Also removes obsolete
+        image versions of typo3gmbh/phpXY.
+
+    -v
+        Enable verbose script output. Shows variables and docker commands.
+
+    -h
+        Show this help.
+
+EOF
+
+# Test if docker-compose exists, else exit out with error
+if ! type "docker-compose" > /dev/null; then
+  echo "This script relies on docker and docker-compose. Please install" >&2
+  exit 1
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called.
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$THIS_SCRIPT_DIR" || exit 1
+
+# Go to directory that contains the local docker-compose.yml file
+cd ../testing-docker || exit 1
+
+# Option defaults
+ROOT_DIR=`realpath ${PWD}/../../`
+TEST_SUITE="unit"
+DBMS="mariadb"
+PHP_VERSION="7.4"
+TYPO3_VERSION="11"
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+EXTRA_TEST_OPTIONS=""
+SCRIPT_VERBOSE=0
+
+# Option parsing
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=();
+# Simple option parsing based on getopts (! not getopt)
+while getopts ":s:d:p:t:e:xy:huv" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        d)
+            DBMS=${OPTARG}
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            ;;
+        t)
+            TYPO3_VERSION=${OPTARG}
+            ;;
+        e)
+            EXTRA_TEST_OPTIONS=${OPTARG}
+            ;;
+        x)
+            PHP_XDEBUG_ON=1
+            ;;
+        y)
+            PHP_XDEBUG_PORT=${OPTARG}
+            ;;
+        h)
+            echo "${HELP}"
+            exit 0
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        v)
+            SCRIPT_VERBOSE=1
+            ;;
+        \?)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+        :)
+            INVALID_OPTIONS+=(${OPTARG})
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "${HELP}" >&2
+    exit 1
+fi
+
+# Move "7.2" to "php72", the latter is the docker container name
+DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+if [ -n "${1}" ]; then
+    TEST_FILE="public/typo3conf/ext/static_info/${1}"
+fi
+
+if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+    set -x
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    clean)
+        rm -rf ../../composer.lock ../../.Build/ ../../composer.json.testing
+        ;;
+    composerUpdate)
+        setUpDockerComposeDotEnv
+        cp ../../composer.json ../../composer.json.orig
+        if [ -f "../../composer.json.testing" ]; then
+            cp ../../composer.json ../../composer.json.orig
+        fi
+        docker-compose run composer_update
+        cp ../../composer.json ../../composer.json.testing
+        mv ../../composer.json.orig ../../composer.json
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    functional)
+        setUpDockerComposeDotEnv
+        case ${DBMS} in
+            mariadb)
+                docker-compose run functional_mariadb10
+                SUITE_EXIT_CODE=$?
+                ;;
+            postgres)
+                docker-compose run functional_postgres10
+                SUITE_EXIT_CODE=$?
+                ;;
+            sqlite)
+                # sqlite has a tmpfs as .Build/Web/typo3temp/var/tests/functional-sqlite-dbs/
+                # Since docker is executed as root (yay!), the path to this dir is owned by
+                # root if docker creates it. Thank you, docker. We create the path beforehand
+                # to avoid permission issues.
+                mkdir -p ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/
+                docker-compose run functional_sqlite
+                SUITE_EXIT_CODE=$?
+                ;;
+            *)
+                echo "Invalid -d option argument ${DBMS}" >&2
+                echo >&2
+                echo "${HELP}" >&2
+                exit 1
+        esac
+        docker-compose down
+        ;;
+    lint)
+        setUpDockerComposeDotEnv
+        docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    unit)
+        setUpDockerComposeDotEnv
+        docker-compose run unit
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    update)
+        # pull typo3/core-testing-*:latest versions of those ones that exist locally
+        docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
+        docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        ;;
+    *)
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+esac
+
+exit $SUITE_EXIT_CODE

--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" backupGlobals="true" cacheResult="false" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="false" failOnWarning="true" cacheDirectory=".phpunit.cache" requireCoverageMetadata="false">
+  <testsuites>
+    <testsuite name="Unit tests">
+      <directory>../Tests/Unit/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <const name="TYPO3_MODE" value="BE"/>
+    <ini name="display_errors" value="1"/>
+    <env name="TYPO3_CONTEXT" value="Testing"/>
+  </php>
+</phpunit>

--- a/Build/testing-docker/.env
+++ b/Build/testing-docker/.env
@@ -1,0 +1,13 @@
+COMPOSE_PROJECT_NAME=local
+HOST_UID=501
+HOST_HOME=/Users/manuelselbach
+ROOT_DIR=/Volumes/Development/TYPO3/static_info_tables/local_packages/static_info_tables_fr
+HOST_USER=manuelselbach
+TEST_FILE=
+TYPO3_VERSION=11
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+PHP_VERSION=8.1
+DOCKER_PHP_IMAGE=php81
+EXTRA_TEST_OPTIONS=
+SCRIPT_VERBOSE=0

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,0 +1,188 @@
+version: '2.3'
+services:
+  mariadb10:
+    image: mariadb:10
+    environment:
+      MYSQL_ROOT_PASSWORD: funcp
+    tmpfs:
+      - /var/lib/mysql/:rw,noexec,nosuid
+
+  postgres10:
+    image: postgres:10-alpine
+    environment:
+      POSTGRES_PASSWORD: funcp
+      POSTGRES_USER: ${HOST_USER}
+    tmpfs:
+      - /var/lib/postgresql/data:rw,noexec,nosuid
+
+  composer_update:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${TYPO3_VERSION} -eq 11 ]; then
+              composer req --dev --no-update \
+                typo3/cms-composer-installers:^3.0
+              composer req typo3/cms-core:^11.5 --no-update
+        fi
+        if [ ${TYPO3_VERSION} -eq 12 ]; then
+            composer req --dev --no-update \
+               "typo3/cms-composer-installers:^5.0" \
+                typo3/cms-backend:^12.4 \
+                typo3/cms-frontend:^12.4 \
+                typo3/cms-extbase:^12.4 \
+                typo3/cms-fluid:^12.4 \
+                typo3/cms-install:^12.4
+            composer req typo3/cms-core:^12.4 -W --no-update
+        fi
+        composer update --no-progress --no-interaction;
+      "
+
+  functional_mariadb10:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    links:
+      - mariadb10
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mariadb10
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z mariadb10 3306; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  functional_postgres10:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    links:
+      - postgres10
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: pdo_pgsql
+      typo3DatabaseName: bamboo
+      typo3DatabaseUsername: ${HOST_USER}
+      typo3DatabaseHost: postgres10
+      typo3DatabasePassword: funcp
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z postgres10 5432; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        else
+          DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        fi
+      "
+
+  functional_sqlite:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    tmpfs:
+      - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
+    environment:
+      typo3DatabaseDriver: pdo_sqlite
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        else
+          DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
+          .Build/bin/phpunit -c Build/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        fi
+      "
+
+  lint:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
+      "
+
+  unit:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP'
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          .Build/bin/phpunit -c Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          DOCKER_HOST=`route -n | awk '/^0.0.0.0/ { print $$2 }'`
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=$${DOCKER_HOST}\" \
+          .Build/bin/phpunit -c Build/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "

--- a/Configuration/TCA/Overrides/static_countries.php
+++ b/Configuration/TCA/Overrides/static_countries.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3_MODE') || die();
-
 (static function (string $dataSetName) {
     $additionalFields = [
         'cn_short_en' => 'cn_short_fr'

--- a/Configuration/TCA/Overrides/static_country_zones.php
+++ b/Configuration/TCA/Overrides/static_country_zones.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3_MODE') || die();
-
 (static function (string $dataSetName) {
     $additionalFields = [
         'zn_name_en' => 'zn_name_fr'

--- a/Configuration/TCA/Overrides/static_currencies.php
+++ b/Configuration/TCA/Overrides/static_currencies.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3_MODE') || die();
-
 (static function (string $dataSetName) {
     $additionalFields = [
         'cu_name_en' => 'cu_name_fr',

--- a/Configuration/TCA/Overrides/static_languages.php
+++ b/Configuration/TCA/Overrides/static_languages.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3_MODE') || die();
-
 (static function (string $dataSetName) {
     $additionalFields = [
         'lg_name_en' => 'lg_name_fr'

--- a/Configuration/TCA/Overrides/static_territories.php
+++ b/Configuration/TCA/Overrides/static_territories.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-defined('TYPO3_MODE') || die();
-
 (static function (string $dataSetName) {
     $additionalFields = [
         'tr_name_en' => 'tr_name_fr'

--- a/Tests/Unit/Domain/Model/CountryTest.php
+++ b/Tests/Unit/Domain/Model/CountryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mselbach\StaticInfoTablesFr\Tests\Unit\Domain\Model;
 
-use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class CountryTest extends UnitTestCase
 {

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mselbach\StaticInfoTablesFr;
 
 /***************************************************************
@@ -24,12 +27,10 @@ namespace Mselbach\StaticInfoTablesFr;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Mselbach\StaticInfoTablesFr\Extension;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 use SJBR\StaticInfoTables\Cache\ClassCacheManager;
 use SJBR\StaticInfoTables\Utility\DatabaseUpdateUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Class for updating the db
@@ -44,20 +45,19 @@ class ext_update
     public function main()
     {
         $content = '';
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
         // Clear the class cache
         /** @var ClassCacheManager $classCacheManager */
-        $classCacheManager = $objectManager->get(ClassCacheManager::class);
+        $classCacheManager = GeneralUtility::makeInstance(ClassCacheManager::class);
         $classCacheManager->reBuild();
 
         // Update the database
         /** @var DatabaseUpdateUtility $databaseUpdateUtility */
-        $databaseUpdateUtility = $objectManager->get(DatabaseUpdateUtility::class);
+        $databaseUpdateUtility = GeneralUtility::makeInstance(DatabaseUpdateUtility::class);
         $databaseUpdateUtility->doUpdate(Extension::EXTENSION_KEY);
 
         $updateLanguageLabels = LocalizationUtility::translate('updateLanguageLabels', 'StaticInfoTables');
-        return '<p>' . $updateLanguageLabels . ' '. Extension::EXTENSION_KEY . '</p>';
+        return '<p>' . $updateLanguageLabels . ' ' . Extension::EXTENSION_KEY . '</p>';
     }
 
     /**

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -42,7 +42,7 @@ class ext_update
      *
      * @return string HTML
      */
-    public function main()
+    public function main(): string
     {
         $content = '';
 
@@ -63,7 +63,7 @@ class ext_update
     /**
      * @return bool
      */
-    public function access()
+    public function access(): bool
     {
         return true;
     }

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "squizlabs/php_codesniffer": "^3.5",
     "typo3/testing-framework": "^8.0",
     "phpstan/extension-installer": "^1.0",
-    "phpstan/phpstan": "^0.12.67",
-    "phpstan/phpstan-deprecation-rules": "^0.12.5",
-    "saschaegerer/phpstan-typo3": "^0.13.1"
+    "phpstan/phpstan": "^1.8",
+    "phpstan/phpstan-deprecation-rules": "^1.1",
+    "saschaegerer/phpstan-typo3": "^1.9"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "require-dev": {
     "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5",
-    "nimut/testing-framework": "^6.0",
+    "typo3/testing-framework": "^8.0",
     "phpstan/extension-installer": "^1.0",
     "phpstan/phpstan": "^0.12.67",
     "phpstan/phpstan-deprecation-rules": "^0.12.5",

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "mselbach/static-info-tables-fr": "self.version"
   },
   "require": {
-    "php": ">=7.4",
-    "typo3/cms-core": "^11.5 || dev-master",
-    "sjbr/static-info-tables": "^11.5"
+    "php": "^8.1",
+    "typo3/cms-core": "^12.4 || dev-master",
+    "sjbr/static-info-tables": "^11.5 || dev-master"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,12 @@
   },
   "config": {
     "vendor-dir": ".Build/vendor",
-    "bin-dir": ".Build/bin"
+    "bin-dir": ".Build/bin",
+    "allow-plugins": {
+      "typo3/cms-composer-installers": true,
+      "typo3/class-alias-loader": true,
+      "phpstan/extension-installer": true
+    }
   },
   "extra": {
     "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "replace": {
-    "mselbach/static-info-tables-fr": "self.version"
+    "typo3-ter/static-info-tables-fr": "self.version"
   },
   "require": {
     "php": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require": {
     "php": "^8.1",
-    "typo3/cms-core": "^12.4 || dev-master",
+    "typo3/cms-core": "^12.4 || dev-main",
     "sjbr/static-info-tables": "^11.5 || dev-master"
   },
   "require-dev": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,4 @@
 <?php
-defined('TYPO3_MODE') or die();
 
 (function ($extKey) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,26 +8,6 @@ parameters:
 
     ignoreErrors:
         -
-            message: "#^Right side of || is always false\\.$#"
-            count: 1
-            path: Configuration/TCA/Overrides/static_countries.php
-        -
-            message: "#^Right side of || is always false\\.$#"
-            count: 1
-            path: Configuration/TCA/Overrides/static_country_zones.php
-        -
-            message: "#^Right side of || is always false\\.$#"
-            count: 1
-            path: Configuration/TCA/Overrides/static_currencies.php
-        -
-            message: "#^Right side of || is always false\\.$#"
-            count: 1
-            path: Configuration/TCA/Overrides/static_languages.php
-        -
-            message: "#^Right side of || is always false\\.$#"
-            count: 1
-            path: Configuration/TCA/Overrides/static_territories.php
-        -
             message: "#^Call to an undefined method SJBR\\\\StaticInfoTables\\\\Domain\\\\Model\\\\CountryZone::getLocalName\\(\\)\\.$#"
             count: 1
             path: Classes/Domain/Model/CountryZone.php


### PR DESCRIPTION
With this PR the compatibility to TYPO3 v12 is established. Thanks again to @dmitryd for providing the initial changes in PR #14.

As mentioned in the conversation, there are 2 issues now. One for the changes to be compatible with TYPO3 v12 and another to update the dependencies to sjbr/static_info_tables and the next version that supports TYPO3 v12.

Furthermore there are some adaptions made to the Github actions, as they were broken.